### PR TITLE
Add hourly_usage and daily_usage attributes for graphing (#4)

### DIFF
--- a/custom_components/powershop/api.py
+++ b/custom_components/powershop/api.py
@@ -644,7 +644,7 @@ class PowershopAPIClient:
         future_meas: List[List[Dict[str, Any]]] = list(results[2: 2 + n_future])
         future_vouchers: List[List[Dict[str, Any]]] = list(results[2 + n_future:])
 
-        # ── Usage ──────────────────────────────────────────────────────────
+        # Usage
         usage_today_kwh = round(
             sum(float(n.get("value") or 0) for n in hourly_nodes), 3
         )
@@ -652,7 +652,7 @@ class PowershopAPIClient:
             sum(float(n.get("value") or 0) for n in daily_nodes), 3
         )
 
-        # ── Daily standing charge (first available daily node) ────────────
+        # Daily standing charge (first available daily node)
         daily_charge_cents: Optional[float] = None
         for node in daily_nodes:
             for stat in (node.get("metaData") or {}).get("statistics", []):
@@ -664,7 +664,7 @@ class PowershopAPIClient:
             if daily_charge_cents is not None:
                 break
 
-        # ── Cost split: ACTUAL (USED) vs all days including ESTIMATED (EST) ──
+        # Cost split: ACTUAL (USED) vs all days including ESTIMATED (EST)
         cost_used_cents = 0.0
         cost_estimated_cents = 0.0
         for node in daily_nodes:
@@ -681,7 +681,7 @@ class PowershopAPIClient:
         cost_used_nzd = round(cost_used_cents / 100, 2)
         cost_estimated_nzd = round(cost_estimated_cents / 100, 2)
 
-        # ── Voucher totals (all currently redeemable packs) ────────────────
+        # Voucher totals (all currently redeemable packs)
         voucher_balance_nzd = round(
             sum(float(v.get("balance") or 0) for v in voucher_nodes) / 100, 2
         )
@@ -697,7 +697,7 @@ class PowershopAPIClient:
             if float(v.get("balance") or 0) > 0
         ]
 
-        # ── Gauge calculations: current period ─────────────────────────────
+        # Gauge calculations: current period
         cost_still_to_buy_nzd = round(
             max(0.0, cost_estimated_nzd - voucher_balance_nzd), 2
         )
@@ -708,7 +708,7 @@ class PowershopAPIClient:
             1,
         )
 
-        # ── Upcoming billing periods ───────────────────────────────────────
+        # Upcoming billing periods
         upcoming_periods: List[Dict[str, Any]] = []
         # Pool of currently redeemable packs available to cover future periods.
         # Subtract dedicated future packs (counted per-period to avoid double-counting)
@@ -763,6 +763,45 @@ class PowershopAPIClient:
                 }
             )
 
+        # Hourly usage attribute
+        hourly_usage = [
+            {
+                "start_at": n.get("startAt"),
+                "end_at": n.get("endAt"),
+                "read_at": n.get("readAt"),
+                "kwh": round(float(n.get("value") or 0), 4),
+                "cost_incl_tax_estimated_nzd": round(
+                    sum(
+                        float((s.get("costInclTax") or {}).get("estimatedAmount") or 0)
+                        for s in (n.get("metaData") or {}).get("statistics", [])
+                        if s.get("type") == "CONSUMPTION_COST"
+                    ) / 100,
+                    4,
+                ),
+            }
+            for n in hourly_nodes
+        ]
+
+        # Daily usage attribute
+        daily_usage = [
+            {
+                "date": n.get("startAt", "")[:10] if n.get("startAt") else None,
+                "start_at": n.get("startAt"),
+                "end_at": n.get("endAt"),
+                "read_at": n.get("readAt"),
+                "kwh": round(float(n.get("value") or 0), 4),
+                "reading_quality": (n.get("metaData") or {}).get("utilityFilters", {}).get("readingQuality"),
+                "cost_incl_tax_estimated_nzd": round(
+                    sum(
+                        float((s.get("costInclTax") or {}).get("estimatedAmount") or 0)
+                        for s in (n.get("metaData") or {}).get("statistics", [])
+                    ) / 100,
+                    4,
+                ),
+            }
+            for n in daily_nodes
+        ]
+
         return {
             "measurement_ok": measurement_ok,
             "balance": balance,
@@ -785,4 +824,6 @@ class PowershopAPIClient:
             "voucher_count": len(voucher_list),
             "upcoming_periods": upcoming_periods,
             "daily_charge_nzd": round(daily_charge_cents / 100, 4) if daily_charge_cents is not None else None,
+            "hourly_usage": hourly_usage,
+            "daily_usage": daily_usage,
         }

--- a/custom_components/powershop/manifest.json
+++ b/custom_components/powershop/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "powershop",
   "name": "Powershop NZ",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "documentation": "https://github.com/PMKA/powershop-nz",
   "issue_tracker": "https://github.com/PMKA/powershop-nz/issues",
   "codeowners": ["@PMKA"],

--- a/custom_components/powershop/sensor.py
+++ b/custom_components/powershop/sensor.py
@@ -184,6 +184,7 @@ class PowershopDataUpdateCoordinator(DataUpdateCoordinator):
             "usage_today_kwh", "usage_period_kwh", "cost_period_nzd",
             "cost_used_nzd", "cost_estimated_nzd", "cost_still_to_buy_nzd",
             "period_coverage_pct", "upcoming_periods", "daily_charge_nzd",
+            "hourly_usage", "daily_usage",
         )
         if not data.get("measurement_ok", True):
             self._measurement_fail_count += 1
@@ -318,6 +319,14 @@ class PowershopSensor(CoordinatorEntity, SensorEntity):
         if self.entity_description.key == "voucher_balance":
             attrs["voucher_count"] = data.get("voucher_count")
             attrs["vouchers"] = data.get("voucher_list", [])
+
+        if self.entity_description.key == "usage_today":
+            attrs["hourly_usage"] = data.get("hourly_usage", [])
+
+        if self.entity_description.key == "usage_billing_period":
+            attrs["billing_period_start"] = data.get("period_start")
+            attrs["billing_period_end"] = data.get("period_end")
+            attrs["daily_usage"] = data.get("daily_usage", [])
 
         rate_periods = data.get("rate_periods", {})
         if self.entity_description.key in ("off_peak_rate", "peak_rate", "shoulder_rate"):


### PR DESCRIPTION
Adds two new sensor attributes for use with ApexCharts and similar dashboard cards.

### `sensor.powershop_usage_today`: `hourly_usage`
List of hourly entries for today:
- `start_at`, `end_at`, `read_at`
- `kwh`
- `cost_incl_tax_estimated_nzd`

### `sensor.powershop_usage_billing_period` : `daily_usage`
List of daily entries for the current billing period:
- `date`, `start_at`, `end_at`, `read_at`
- `kwh`
- `reading_quality` (`ACTUAL` or `ESTIMATED`)
- `cost_incl_tax_estimated_nzd`

Closes #4