### PR TITLE
Fix hourly usage date and expose reading quality

### DIFF
--- a/custom_components/powershop_nz/api.py
+++ b/custom_components/powershop_nz/api.py
@@ -5,6 +5,7 @@ import logging
 import re
 from calendar import monthrange
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
 from typing import Any, Dict, List, Optional
 
 import aiohttp
@@ -102,6 +103,11 @@ query measurements(
                 endAt
               }
               metaData {
+                utilityFilters {
+                  ... on ElectricityFiltersOutput {
+                    readingQuality
+                  }
+                }
                 statistics {
                   type
                   value
@@ -602,17 +608,20 @@ class PowershopAPIClient:
             else []
         )
 
-        # Fetch all measurements + future period vouchers concurrently
-        tomorrow = (date.today() + timedelta(days=1)).isoformat()
+        # Fetch all measurements + future period vouchers concurrently.
+        # The Powershop API treats endOn as inclusive, so use the Auckland-local
+        # current date for today's 24 hourly rows.
+        local_today = datetime.now(ZoneInfo("Pacific/Auckland")).date()
+        today = local_today.isoformat()
         coros = (
             [
-                # hourly today (uses last/endOn — existing query, no readingQuality needed)
-                self.get_measurements(account_number, property_id, 24, tomorrow, "HOUR_INTERVAL"),
+                # hourly today (uses last/endOn; endOn is inclusive)
+                self.get_measurements(account_number, property_id, 24, today, "HOUR_INTERVAL"),
                 # current billing period daily (with readingQuality for USED/EST split)
                 self.get_measurements_date_range(
                     account_number, property_id,
-                    period_start or (date.today() - timedelta(days=30)).isoformat(),
-                    period_end or date.today().isoformat(),
+                    period_start or (local_today - timedelta(days=30)).isoformat(),
+                    period_end or today,
                 ),
             ]
             + [
@@ -770,6 +779,7 @@ class PowershopAPIClient:
                 "end_at": n.get("endAt"),
                 "read_at": n.get("readAt"),
                 "kwh": round(float(n.get("value") or 0), 4),
+                "reading_quality": (n.get("metaData") or {}).get("utilityFilters", {}).get("readingQuality"),
                 "cost_incl_tax_estimated_nzd": round(
                     sum(
                         float((s.get("costInclTax") or {}).get("estimatedAmount") or 0)


### PR DESCRIPTION
### Summary

Fixes `sensor.powershop_nz_usage_today` returning tomorrow's 24 estimated hourly entries rather than today's entries.

Also exposes `reading_quality` on each `hourly_usage` item, matching the quality information already available for daily usage rows.

### Cause

The Powershop measurements API appears to treat `endOn` as inclusive.

The existing query requested the last 24 hourly entries with endOn set to tomorrow, which returned tomorrow's forecast rows.

### Changes

- Use Auckland-local today rather than tomorrow for the hourly endOn value
- Request `metaData.utilityFilters.readingQuality` in the hourly measurements query
- Expose `reading_quality` on each `hourly_usage` entry
- Use the same Auckland-local date for the daily fallback range

### Tested locally

Before the patch, while HA local date was 23 May, `hourly_usage` contained entries for 24 May.

After the patch, tested on a live Home Assistant installation:

- HA local time: `2026-06-04T14:06:00+12:00`
- hourly usage entries: `24`
- first entry: `2026-06-04T00:00:00+12:00`
- last entry: `2026-06-04T23:00:00+12:00`
- hourly `reading_quality`: `ESTIMATE`

This confirms the exposed hourly rows now align with the Auckland-local current date.