### PR TITLE
Add selected-date hourly usage action

### DIFF
--- a/custom_components/powershop_nz/__init__.py
+++ b/custom_components/powershop_nz/__init__.py
@@ -1,16 +1,114 @@
 """Powershop integration for Home Assistant."""
 import logging
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+import voluptuous as vol
 
-from .api import AuthError, PowershopAPIClient
-from .const import CONF_REFRESH_TOKEN, DOMAIN
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    ServiceResponse,
+    SupportsResponse,
+)
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from .api import PowershopAPIClient, normalise_hourly_usage
+from .const import (
+    ATTR_CONFIG_ENTRY_ID,
+    ATTR_DATE,
+    CONF_ACCOUNT_NUMBER,
+    CONF_PROPERTY_ID,
+    CONF_REFRESH_TOKEN,
+    DOMAIN,
+    SERVICE_GET_HOURLY_USAGE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
+
+_SERVICE_GET_HOURLY_USAGE_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_CONFIG_ENTRY_ID): str,
+        vol.Required(ATTR_DATE): cv.date,
+    }
+)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up Powershop service actions."""
+    hass.data.setdefault(DOMAIN, {})
+
+    async def async_get_hourly_usage(call: ServiceCall) -> ServiceResponse:
+        """Return hourly usage rows for a selected date."""
+        entry_id = call.data.get(ATTR_CONFIG_ENTRY_ID)
+        requested_date = call.data[ATTR_DATE]
+
+        if entry_id is None:
+            loaded_entries = [
+                entry
+                for entry in hass.config_entries.async_entries(DOMAIN)
+                if entry.state is ConfigEntryState.LOADED
+            ]
+            if not loaded_entries:
+                raise ServiceValidationError("No loaded Powershop NZ config entry found")
+            if len(loaded_entries) > 1:
+                raise ServiceValidationError(
+                    "Multiple loaded Powershop NZ config entries found; "
+                    "specify config_entry_id in YAML mode"
+                )
+            entry = loaded_entries[0]
+            entry_id = entry.entry_id
+        else:
+            entry = hass.config_entries.async_get_entry(entry_id)
+
+        if entry is None or entry.domain != DOMAIN:
+            raise ServiceValidationError("Powershop NZ config entry not found")
+        if entry.state is not ConfigEntryState.LOADED:
+            raise ServiceValidationError("Powershop NZ config entry is not loaded")
+
+        coordinator = hass.data.get(DOMAIN, {}).get(entry_id)
+        if coordinator is None:
+            raise ServiceValidationError("Powershop NZ coordinator is not available")
+
+        account_number = entry.data.get(CONF_ACCOUNT_NUMBER)
+        property_id = entry.data.get(CONF_PROPERTY_ID)
+        if not account_number or not property_id:
+            raise ServiceValidationError(
+                "Powershop NZ account or property is not configured"
+            )
+
+        nodes = await coordinator.client.get_measurements(
+            account_number,
+            property_id,
+            24,
+            requested_date.isoformat(),
+            "HOUR_INTERVAL",
+        )
+        hourly_usage = normalise_hourly_usage(nodes)
+
+        return {
+            "date": requested_date.isoformat(),
+            "hourly_usage_count": len(hourly_usage),
+            "total_kwh": round(sum(row["kwh"] for row in hourly_usage), 3),
+            "total_cost_incl_tax_estimated_nzd": round(
+                sum(row["cost_incl_tax_estimated_nzd"] for row in hourly_usage),
+                2,
+            ),
+            "hourly_usage": hourly_usage,
+        }
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_GET_HOURLY_USAGE,
+        async_get_hourly_usage,
+        schema=_SERVICE_GET_HOURLY_USAGE_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/powershop_nz/api.py
+++ b/custom_components/powershop_nz/api.py
@@ -275,6 +275,35 @@ def _parse_rate(formatted: str) -> Optional[float]:
     return float(match.group(1)) if match else None
 
 
+def normalise_hourly_usage(nodes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return Home Assistant-friendly hourly usage rows."""
+    return [
+        {
+            "start_at": node.get("startAt"),
+            "end_at": node.get("endAt"),
+            "read_at": node.get("readAt"),
+            "kwh": round(float(node.get("value") or 0), 4),
+            "reading_quality": (
+                ((node.get("metaData") or {}).get("utilityFilters") or {}).get(
+                    "readingQuality"
+                )
+            ),
+            "cost_incl_tax_estimated_nzd": round(
+                sum(
+                    float(
+                        (stat.get("costInclTax") or {}).get("estimatedAmount") or 0
+                    )
+                    for stat in (node.get("metaData") or {}).get("statistics", [])
+                    if stat.get("type") == "CONSUMPTION_COST"
+                )
+                / 100,
+                4,
+            ),
+        }
+        for node in nodes
+    ]
+
+
 def _next_billing_periods(
     period_start: str, period_end: str, count: int = 5
 ) -> List[Dict[str, str]]:
@@ -773,24 +802,7 @@ class PowershopAPIClient:
             )
 
         # Hourly usage attribute
-        hourly_usage = [
-            {
-                "start_at": n.get("startAt"),
-                "end_at": n.get("endAt"),
-                "read_at": n.get("readAt"),
-                "kwh": round(float(n.get("value") or 0), 4),
-                "reading_quality": ((n.get("metaData") or {}).get("utilityFilters") or {}).get("readingQuality"),
-                "cost_incl_tax_estimated_nzd": round(
-                    sum(
-                        float((s.get("costInclTax") or {}).get("estimatedAmount") or 0)
-                        for s in (n.get("metaData") or {}).get("statistics", [])
-                        if s.get("type") == "CONSUMPTION_COST"
-                    ) / 100,
-                    4,
-                ),
-            }
-            for n in hourly_nodes
-        ]
+        hourly_usage = normalise_hourly_usage(hourly_nodes)
 
         # Daily usage attribute
         daily_usage = [

--- a/custom_components/powershop_nz/const.py
+++ b/custom_components/powershop_nz/const.py
@@ -8,6 +8,11 @@ CONF_REFRESH_TOKEN = "refresh_token"
 CONF_ACCOUNT_NUMBER = "account_number"
 CONF_PROPERTY_ID = "property_id"
 
+# Service action names and fields
+SERVICE_GET_HOURLY_USAGE = "get_hourly_usage"
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+ATTR_DATE = "date"
+
 # Production Firebase config — Powershop's own public project identifier.
 #
 # NOTE: This is NOT a secret credential.

--- a/custom_components/powershop_nz/services.yaml
+++ b/custom_components/powershop_nz/services.yaml
@@ -1,0 +1,7 @@
+get_hourly_usage:
+  fields:
+    date:
+      required: true
+      example: "2026-06-07"
+      selector:
+        date:

--- a/custom_components/powershop_nz/strings.json
+++ b/custom_components/powershop_nz/strings.json
@@ -40,5 +40,17 @@
       "already_configured": "This Powershop account is already configured.",
       "reauth_successful": "Re-authentication was successful."
     }
+  },
+  "services": {
+    "get_hourly_usage": {
+      "name": "Get hourly usage",
+      "description": "Fetch hourly electricity usage and Powershop-provided estimated cost data for a selected date.",
+      "fields": {
+        "date": {
+          "name": "Date",
+          "description": "The date to retrieve hourly usage for."
+        }
+      }
+    }
   }
 }

--- a/custom_components/powershop_nz/translations/en.json
+++ b/custom_components/powershop_nz/translations/en.json
@@ -40,5 +40,17 @@
       "already_configured": "This Powershop account is already configured.",
       "reauth_successful": "Re-authentication was successful."
     }
+  },
+  "services": {
+    "get_hourly_usage": {
+      "name": "Get hourly usage",
+      "description": "Fetch hourly electricity usage and Powershop-provided estimated cost data for a selected date.",
+      "fields": {
+        "date": {
+          "name": "Date",
+          "description": "The date to retrieve hourly usage for."
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Description:

## Summary

Adds a response-only Home Assistant action:

`powershop_nz.get_hourly_usage`

The action fetches and returns 24 hourly usage entries for a selected date.

This complements the existing `sensor.powershop_nz_usage_today` attribute by allowing users to retrieve historical hourly data for a particular day without exposing a large historical dataset as sensor attributes.

## Action input

```yaml
action: powershop_nz.get_hourly_usage
data:
  date: "2026-06-05"
```

For the common case where there is one loaded Powershop NZ config entry, the action automatically uses that entry.

An optional `config_entry_id` can still be supplied manually in YAML for users with multiple loaded Powershop NZ entries.

## Returned data

The response includes:

* `date`
* `hourly_usage_count`
* `total_kwh`
* `total_cost_incl_tax_estimated_nzd`
* `hourly_usage`

Each hourly item contains:

* `start_at`
* `end_at`
* `read_at`
* `kwh`
* `reading_quality`
* `cost_incl_tax_estimated_nzd`

## Tested locally

Historical settled day:

* date: `2026-06-05`
* hourly rows: `24`
* reading quality: `ACTUAL`
* total kWh: `36.966`
* total estimated cost incl. tax: `$11.69`

Current day:

* date: `2026-06-08`
* hourly rows: `24`
* reading quality: `ESTIMATE`
* total kWh: `34.921`
* total estimated cost incl. tax: `$11.09`

The action was tested from Home Assistant Developer Tools → Actions using the simplified date-only UI.

## Files changed

* `api.py`
* `__init__.py`
* `const.py`
* new `services.yaml`
* `strings.json`
* `translations/en.json`
