### PR TITLE
Fix daily_charge sensor state_class validation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Your account number and property ID are discovered automatically. Home Assistant
 
 ## 📝 Changelog
 
+### v2.1.4 (2026-06-23)
+- Fixed `sensor.powershop_nz_daily_charge` logging a HA validation warning on startup — the sensor was incorrectly using `state_class=MEASUREMENT` with `device_class=MONETARY`, which HA does not allow. The daily standing charge is a fixed tariff rate, not an accumulating total, so it now uses `state_class=None` with no device class — matching the pattern of the other rate sensors
+
 ### v2.1.3 (2026-06-14)
 - Fixed `sensor.powershop_nz_peak_rate` returning the Off Peak rate value instead of the true Peak rate — rate label matching was doing a substring check so `"peak"` matched `"Off Peak"` first
 - Added `powershop_nz.get_hourly_usage` service action — fetch 24 hourly usage entries for any selected date, useful for historical data without polluting sensor attributes. Thanks @gromitn!

--- a/custom_components/powershop_nz/manifest.json
+++ b/custom_components/powershop_nz/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "powershop_nz",
   "name": "Powershop NZ",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "documentation": "https://github.com/PMKA/powershop-nz",
   "issue_tracker": "https://github.com/PMKA/powershop-nz/issues",
   "codeowners": ["@PMKA"],

--- a/custom_components/powershop_nz/sensor.py
+++ b/custom_components/powershop_nz/sensor.py
@@ -135,8 +135,7 @@ SENSORS = [
         key="daily_charge",
         name="Daily Standing Charge",
         native_unit_of_measurement="NZD",
-        device_class=SensorDeviceClass.MONETARY,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=None,
         icon="mdi:calendar-today",
     ),
 ]


### PR DESCRIPTION
## Summary

- Removes invalid `state_class=MEASUREMENT` / `device_class=MONETARY` combination from the Daily Standing Charge sensor that was producing a HA validation warning

## What was wrong

HA requires monetary sensors to use `state_class=None` or `state_class=TOTAL` â€” `MEASUREMENT` is not valid for that device class, producing this log warning on every HA start:

> Entity sensor.powershop_nz_daily_charge is using state class 'measurement' which is impossible considering device class ('monetary') it is using; expected None or one of 'total'

## Fix

The daily standing charge is a fixed tariff rate (NZD/day), not a cumulative amount â€” semantically the same as the c/kWh rate sensors rather than the balance or cost sensors. Changed to `state_class=None` with no `device_class`, matching the pattern used by `off_peak_rate`, `peak_rate`, and `shoulder_rate`.

## Impact on existing users

- The warning is silenced
- The sensor value is unchanged
- HA will no longer record long-term statistics for this sensor (the value is a fixed rate that rarely changes, so the stat was a flat line anyway)
- No entity ID changes
